### PR TITLE
Update utilities for new Apple Music image URL

### DIFF
--- a/src/components/track.tsx
+++ b/src/components/track.tsx
@@ -155,5 +155,5 @@ function getAppleMusicImageUrl(
   baseUrl: string,
   dimensions: AppleMusicImageDimensions,
 ): string {
-  return `${baseUrl}/source/${dimensions}x${dimensions}bb.jpg`
+  return `${baseUrl}/${dimensions}x${dimensions}bb.jpg`
 }

--- a/src/pages/this-is-my-jam/[id]/index.tsx
+++ b/src/pages/this-is-my-jam/[id]/index.tsx
@@ -87,7 +87,10 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
         name,
         album->{
           name,
-          appleMusicImageUrl,
+          "appleMusicImageUrl": coalesce(
+            appleMusicImageUrl,
+            image.asset->url
+          ),
           'color': image.asset->metadata.palette.dominant.background,
         },
         artists[]->{

--- a/src/pages/this-is-my-jam/[id]/og-image.tsx
+++ b/src/pages/this-is-my-jam/[id]/og-image.tsx
@@ -197,5 +197,5 @@ function getAppleMusicImageUrl(
   baseUrl: string,
   dimensions: AppleMusicImageDimensions,
 ): string {
-  return `${baseUrl}/source/${dimensions}x${dimensions}bb.jpg`
+  return `${baseUrl}/${dimensions}x${dimensions}bb.jpg`
 }

--- a/src/pages/this-is-my-jam/[id]/og-image.tsx
+++ b/src/pages/this-is-my-jam/[id]/og-image.tsx
@@ -99,7 +99,10 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
         name,
         album->{
           name,
-          appleMusicImageUrl,
+          "appleMusicImageUrl": coalesce(
+            appleMusicImageUrl,
+            image.asset->url
+          ),
           'color': image.asset->metadata.palette.dominant.background,
         },
         artists[]->{


### PR DESCRIPTION
If the image doesn't exist, load it from Sanity.